### PR TITLE
Update driver.py

### DIFF
--- a/novadocker/virt/docker/driver.py
+++ b/novadocker/virt/docker/driver.py
@@ -353,6 +353,7 @@ class DockerDriver(driver.ComputeDriver):
             return
         try:
             self.plug_vifs(instance, network_info)
+            self._attach_vifs(instance, network_info)
         except Exception as e:
             LOG.warning(_('Cannot setup network on reboot: {0}').format(e))
             return


### PR DESCRIPTION
it's a bug. 
the container doesn't have any interface of network except lo when soft reboot it on the website of openstack dashboard.

the commit is a solution for the bug.   attach a vifs to the container.