### PR TITLE
Fix docker 1.7.0

### DIFF
--- a/novadocker/virt/docker/client.py
+++ b/novadocker/virt/docker/client.py
@@ -95,7 +95,7 @@ class UnixHTTPConnection(httplib.HTTPConnection):
 
 
 class DockerHTTPClient(object):
-    VERSION = 'v1.13'
+    VERSION = 'v1.14'
 
     def __init__(self, connection=None):
         self._connection = connection

--- a/novadocker/virt/docker/client.py
+++ b/novadocker/virt/docker/client.py
@@ -95,7 +95,7 @@ class UnixHTTPConnection(httplib.HTTPConnection):
 
 
 class DockerHTTPClient(object):
-    VERSION = 'v1.14'
+    VERSION = 'v1.13'
 
     def __init__(self, connection=None):
         self._connection = connection
@@ -152,7 +152,7 @@ class DockerHTTPClient(object):
             'Dns': None,
             'Image': None,
             'Volumes': {},
-            'VolumesFrom': '',
+            'VolumesFrom': None,
         }
         data.update(args)
         resp = self.make_request(

--- a/novadocker/virt/docker/client.py
+++ b/novadocker/virt/docker/client.py
@@ -152,7 +152,6 @@ class DockerHTTPClient(object):
             'Dns': None,
             'Image': None,
             'Volumes': {},
-            'VolumesFrom': None,
         }
         data.update(args)
         resp = self.make_request(


### PR DESCRIPTION
Although the API spec says that for versions below 1.17, VolumesFrom should be an empty string rather than null, docker 1.7.0 gives an error if this value is not a list or null. This is probably a bug in docker, but for now, the most straightforward thing to do is just omit the VolumesFrom value and leave it to the default setting when not specified.