### PR TITLE
Fixing issues being encountered in devstack run

### DIFF
--- a/contrib/devstack/extras.d/70-docker.sh
+++ b/contrib/devstack/extras.d/70-docker.sh
@@ -45,13 +45,13 @@ if [[ $VIRT_DRIVER == "docker" ]]; then
       install_package python-software-properties && \
           sudo sh -c "echo deb $DOCKER_APT_REPO docker main > /etc/apt/sources.list.d/docker.list"
       apt_get update
-      install_package --force-yes lxc-docker socat
+      install_package --force-yes lxc-docker-1.7.0 socat
     fi
 
     # Enable debug level logging
     if [ -f "/etc/default/docker" ]; then
         sudo cat /etc/default/docker
-        sudo sed -i 's/^.*DOCKER_OPTS=.*$/DOCKER_OPTS=\"--debug --storage-opt dm.override_udev_sync_check=true\"/' /etc/default/docker
+        sudo sed -i 's/^.*DOCKER_OPTS=.*$/DOCKER_OPTS=\"--debug -s dm.override_udev_sync_check=true\"/' /etc/default/docker
         sudo cat /etc/default/docker
     fi
     if [ -f "/etc/sysconfig/docker" ]; then

--- a/novadocker/virt/docker/driver.py
+++ b/novadocker/virt/docker/driver.py
@@ -28,6 +28,7 @@ from docker import errors
 from oslo_config import cfg
 from oslo_log import log
 from oslo_serialization import jsonutils
+from oslo_utils import fileutils
 from oslo_utils import importutils
 from oslo_utils import units
 
@@ -40,7 +41,6 @@ from nova.compute import vm_mode
 from nova import exception
 from nova.image import glance
 from nova import objects
-from nova.openstack.common import fileutils
 from nova import utils
 from nova import utils as nova_utils
 from nova.virt import driver


### PR DESCRIPTION
Three changes.

1) Pinning to version 1.7.0 of docker. The latest version
   (1.7.1) is failing with following error:

   https://code.google.com/p/google-cloud-sdk/issues/detail?id=163

2) Changing command line storage flag option to use single letter key.
   The verbose version of the flag seems no longer supported.

3) fileutils has graduated to oslo
   Check commit 741f163fc528cd1146052b22324928575ec9ac35 in
   https://github.com/openstack/nova/