### PR TITLE
Fix tests on stable/juno

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -2,3 +2,4 @@
 host=review.openstack.org
 port=29418
 project=stackforge/nova-docker.git
+defaultbranch=stable/juno

--- a/contrib/devstack/lib/nova_plugins/hypervisor-docker
+++ b/contrib/devstack/lib/nova_plugins/hypervisor-docker
@@ -76,6 +76,8 @@ function is_docker_running {
     return 0
 }
 
+pip_install docker-py
+
 # install_nova_hypervisor() - Install external components
 function install_nova_hypervisor {
     setup_develop $DOCKER_DIR

--- a/novadocker/tests/virt/docker/test_driver.py
+++ b/novadocker/tests/virt/docker/test_driver.py
@@ -27,14 +27,15 @@ from nova import test
 import nova.tests.image.fake
 from nova.tests import matchers
 from nova.tests import utils
-from nova.tests.virt.test_virt_drivers import _VirtDriverTestCase
+from nova.tests.virt import test_virt_drivers
 from novadocker.tests.virt.docker import mock_client
 import novadocker.virt.docker
 from novadocker.virt.docker import hostinfo
 from novadocker.virt.docker import network
 
 
-class DockerDriverTestCase(_VirtDriverTestCase, test.TestCase):
+class DockerDriverTestCase(test_virt_drivers._VirtDriverTestCase,
+                           test.TestCase):
 
     driver_module = 'novadocker.virt.docker.DockerDriver'
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ hacking>=0.9.2,<0.10
 coverage>=3.6
 discover
 fixtures>=0.3.14
+http://tarballs.openstack.org/nova/nova-stable-juno.tar.gz#egg=nova
 python-subunit
 sphinx>=1.1.2
 oslosphinx

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,7 @@ setenv =
    VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       -egit+https://github.com/openstack/nova#egg=nova
-commands = python setup.py testr --slowest --testr-args='{posargs}'
+commands = python -m nova.openstack.common.lockutils python setup.py testr --slowest --testr-args='{posargs}'
 
 [testenv:pep8]
 commands = flake8


### PR DESCRIPTION
In stable/juno the tox.ini file is pulling nova from master which is
kilo-based. This patch set updates the test requirements to pull nova
from stable/juno.

This patch set also fixes pep8 errors that were fixed in kilo under
8bcecf6faa6a55bf081f5a4a4dad817db768094b and updates the tests so
that they are invoked with a lockpath in the same manner as in
Ib8f7b5b36568195da611892fdcc94354d03a14e7

Lastly, in order to get tempest to pass, docker-py needs to be
installed in the devstack plugin.

Change-Id: Ifc149e14f46c243edd8ffeff860a056d379957dc